### PR TITLE
Remove bench-tps-dos-run directory and directory operation

### DIFF
--- a/dos-run.sh
+++ b/dos-run.sh
@@ -6,7 +6,7 @@ declare -a instance_zone
 
 # change directory to bench-tps-dos dir
 base_dir=$PWD
-dos_run_dir=$base_dir/bench-tps-dos-run
+dos_run_dir=$base_dir/bench-tps-dos
 cd $dos_run_dir
 
 # prepare ENV
@@ -109,8 +109,8 @@ if [[ -f "exec-start-dos-test.sh" ]];then
 fi
 # add git repo to exe-start-template
 echo "git clone https://github.com/solana-labs/bench-tps-dos-test.git" >> exec-start-template.sh
-echo 'cp ~/cluster-ops/bench-tps-dos-run/start-build-solana.sh .' >> exec-start-template.sh
-echo 'cp ~/cluster-ops/bench-tps-dos-run/start-dos-test.sh .' >> exec-start-template.sh
+echo 'cp ~/bench-tps-dos-test/start-build-solana.sh .' >> exec-start-template.sh
+echo 'cp ~/bench-tps-dos-test/start-dos-test.sh .' >> exec-start-template.sh
 
 
 if [[ ! "$BUILD_SOLANA" ]];then

--- a/dos-run.sh
+++ b/dos-run.sh
@@ -4,11 +4,6 @@ declare -a instance_ip
 declare -a instance_name
 declare -a instance_zone
 
-# change directory to bench-tps-dos dir
-base_dir=$PWD
-dos_run_dir=$base_dir/bench-tps-dos
-cd $dos_run_dir
-
 # prepare ENV
 if [[ ! "$GIT_TOKEN" ]];then
 	echo GIT_TOKEN env not found, exit

--- a/exec-start-template.sh
+++ b/exec-start-template.sh
@@ -2,8 +2,8 @@
 source ~/.bashrc
 source ~/.profile
 cd ~
-if [[ -d "bench-tps-dos-run" ]];then
-    rm  "bench-tps-dos-run"
+if [[ -d "bench-tps-dos-test" ]];then
+    rm  "bench-tps-dos-test"
 fi
 if [[ -f "start-build-solana.sh" ]];then
     rm  "start-build-solana.sh"


### PR DESCRIPTION
When the repo move from cluster-ops to this public repo. It does not have the directory any more. The script still do check and operation of bench-tps-dos-run directory and cause buildkite fail. This PR fix the issue.