### PR TITLE
printout bench-cli

### DIFF
--- a/dos-run.sh
+++ b/dos-run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -x
 declare -a instance_ip
 declare -a instance_name
 declare -a instance_zone
@@ -322,7 +322,9 @@ for sship in "${instance_ip[@]}"
 do
 	ret_benchmark=$(ssh -i id_ed25519_dos_test -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" sol@$sship 'bash -s' < exec-start-dos-test.sh)
 done
-
+sleep 1
+ret_ps=$(ps aux | grep solana-bench-tps)
+echo bench-cli:$ret_ps
 echo ----- stage: wait for benchmark to end ------
 sleep_time=$(echo "$DURATION+2" | bc)
 sleep $sleep_time

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -147,8 +147,8 @@ echo keyfile : $base/$KEYPAIR_DIR/$KEYPAIR_FILE
 
 benchmark=$(./solana-bench-tps -u $RPC_ENDPOINT --identity $base/$ID_DIR/$ID_FILE --read-client-keys $base/$KEYPAIR_DIR/$KEYPAIR_FILE \
 		$use_client $sustained $tpu_use_quic $use_durable_nonce $tpu_disable_quic  --duration $duration --tx_count $tx_count --thread-batch-sleep-ms $thread_batch_sleep_ms)
-
 echo $benchmark
+
 ret_ps=$(ps aux | grep solana-bench-tps)
 echo $ret_ps > ps.out
 echo --- end of benchmark $(date)


### PR DESCRIPTION
bench-tps cli  is critical to check if test program  is giving the correct options.
This PR printouts benc-tps cli in process.