### PR TITLE
Build only bench-tps binary to fullfill #30

### DIFF
--- a/start-build-solana.sh
+++ b/start-build-solana.sh
@@ -47,7 +47,9 @@ else
 fi
 git branch || true
 # install solana in  /solana/ci
-cd $base/solana/ci
-res=$(CI_OS_NAME=linux DO_NOT_PUBLISH_TAR=true CHANNEL=$CHANNEL ./publish-tarball.sh)
+#cd $base/solana/ci
+# res=$(CI_OS_NAME=linux DO_NOT_PUBLISH_TAR=true CHANNEL=$CHANNEL ./publish-tarball.sh)
+cd $base/solana/bech-tps
+res=$(cargo build --release)
 echo build result $res
 exit 0

--- a/start-build-solana.sh
+++ b/start-build-solana.sh
@@ -47,9 +47,9 @@ else
 fi
 git branch || true
 # install solana in  /solana/ci
-#cd $base/solana/ci
+#cd $base/solana/ci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
 # res=$(CI_OS_NAME=linux DO_NOT_PUBLISH_TAR=true CHANNEL=$CHANNEL ./publish-tarball.sh)
-cd $base/solana/bech-tps
+cd $base/solana/bench-tps
 res=$(cargo build --release)
 echo build result $res
 exit 0

--- a/start-dos-test.sh
+++ b/start-dos-test.sh
@@ -140,7 +140,8 @@ ret_config_metric=$(exec ./configure-metrics.sh || true )
 echo $ret_config_metric
 
 # benchmark exec
-cd $base/solana/solana-release/bin
+# cd $base/solana/solana-release/bin
+cd $base/solana/target/release
 echo --- start of benchmark $(date)
 echo KEYPAIR_FILE $KEYPAIR_FILE
 echo keyfile : $base/$KEYPAIR_DIR/$KEYPAIR_FILE


### PR DESCRIPTION
This PR improve binary build by only building bench-tps, not all the utilities