### PR TITLE
adding skip-rate to the bench-tps-dos report and influxdb

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -33,14 +33,17 @@ printf -v s_ct_stats_number_of_accts '%s\\n%s\\n%s\\n%s' \
         "$mean_ct_stats_num_of_accts_txt" "$max_ct_stats_num_of_accts_txt" "$p90_ct_stats_num_of_accts_txt" "$p99_ct_stats_num_of_accts_txt"
 printf -v blocks_fill '%s\\n%s\\n%s\\n%s\\n%s' \
         "$total_blocks_txt" "$blocks_fill_50_txt" "$blocks_fill_90_txt" "$blocks_fill_50_percent_txt" "$blocks_fill_90_percent_txt"
+printf -v skip_rate '%s\\n%s\\n%s\\n' \
+        "$mean_skip_rate_txt" "$mean_skip_rate" "$blocks_fill_90_txt"
+
 printf -v buildkite_link  '%s' "[Buildkite]($BUILDKITE_BUILD_URL)"
 printf -v grafana_link  '%s' "[Grafana]($gf_url)"
 # compose report without link
-printf -v test_report '%s    %s\\n%s\\n**Test Details:**\\n```%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n```' \
+printf -v test_report '%s    %s\\n%s\\n**Test Details:**\\n```%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n%s\\n```' \
         "$grafana_link" "$buildkite_link" \
         "$test_config" "$time_range" "$slot_range" \
         "$s_tx_count" "$s_tower_vote_dist" "$s_optimistic_slot_elapsed" \
-        "$s_ct_stats_block_cost" "$s_ct_stats_tx_count" "$s_ct_stats_number_of_accts" "$blocks_fill" 
+        "$s_ct_stats_block_cost" "$s_ct_stats_tx_count" "$s_ct_stats_number_of_accts" "$blocks_fill" "$skip_rate"
 
 # compose discord message
 d_username="\"username\": \"${discord_bot_name}\""

--- a/discord.sh
+++ b/discord.sh
@@ -34,7 +34,7 @@ printf -v s_ct_stats_number_of_accts '%s\\n%s\\n%s\\n%s' \
 printf -v blocks_fill '%s\\n%s\\n%s\\n%s\\n%s' \
         "$total_blocks_txt" "$blocks_fill_50_txt" "$blocks_fill_90_txt" "$blocks_fill_50_percent_txt" "$blocks_fill_90_percent_txt"
 printf -v skip_rate '%s\\n%s\\n%s\\n' \
-        "$mean_skip_rate_txt" "$mean_skip_rate" "$blocks_fill_90_txt"
+        "$mean_skip_rate_txt" "$mean_skip_rate_txt" "$skip_rate_90_txt"
 
 printf -v buildkite_link  '%s' "[Buildkite]($BUILDKITE_BUILD_URL)"
 printf -v grafana_link  '%s' "[Grafana]($gf_url)"

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -23,11 +23,14 @@ fi
 ## setup window interval for query
 window_interval="10s" 
 window_interval_long="10s"
+oversize_window=$(echo "${DURATION}+300" | bc)
+printf -v oversize_window "%ss" "$oversize_window"
 if [[ "$LARGE_DATA_SET" == "true" ]];then
 	[[ ! "$INFLUX_WINDOW_INTERVAL" ]] && INFLUX_WINDOW_INTERVAL="10m"
 	[[ ! "$INFLUX_WINDOW_INTERVAL_LONG" ]] && INFLUX_WINDOW_INTERVAL_LONG="30m"
 	window_interval=$INFLUX_WINDOW_INTERVAL
 	window_interval_long=$INFLUX_WINDOW_INTERVAL_LONG
+	oversize_window="12h"
 fi
 
 ## Configuration
@@ -315,6 +318,21 @@ else
 fi
 blocks_fill_90_percent_txt="blocks_90_full: $percent_value"
 DATAPOINT[blocks_90_full]="$percent_raw_value"
+# skip_rate
+result_input="${FLUX_RESULT['mean_skip_rate']}"
+get_value
+mean_skip_rate_txt="mean_skip_rate: $_value"
+DATAPOINT[mean_skip_rate]="$_value"
+
+result_input="${FLUX_RESULT['max_skip_rate']}"
+get_value
+mean_skip_rate_txt="max_skip_rate: $_value"
+DATAPOINT[max_skip_rate]="$_value"
+
+result_input="${FLUX_RESULT['skip_rate_90']}"
+get_value
+skip_rate_90_txt="skip_rate_90: $_value"
+DATAPOINT[skip_rate_90]="$_value"
 
 #write data report to the influx
 

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -321,17 +321,17 @@ DATAPOINT[blocks_90_full]="$percent_raw_value"
 # skip_rate
 result_input="${FLUX_RESULT['mean_skip_rate']}"
 get_value
-mean_skip_rate_txt="mean_skip_rate: $_value"
+mean_skip_rate_txt="mean_skip_rate: $_value%"
 DATAPOINT[mean_skip_rate]="$_value"
 
 result_input="${FLUX_RESULT['max_skip_rate']}"
 get_value
-mean_skip_rate_txt="max_skip_rate: $_value"
+mean_skip_rate_txt="max_skip_rate: $_value%"
 DATAPOINT[max_skip_rate]="$_value"
 
 result_input="${FLUX_RESULT['skip_rate_90']}"
 get_value
-skip_rate_90_txt="skip_rate_90: $_value"
+skip_rate_90_txt="skip_rate_90: $_value%"
 DATAPOINT[skip_rate_90]="$_value"
 
 #write data report to the influx

--- a/slack.sh
+++ b/slack.sh
@@ -26,8 +26,10 @@ printf -v s_ct_stats_block_cost "%s%s%s%s%s%s%s%s" $mean_ct_stats_block_cost_txt
 printf -v s_ct_stats_tx_count "%s%s%s%s%s%s%s%s" $mean_mean_ct_stats_tx_count_txt "\\n" $max_mean_ct_stats_tx_count_txt "\\n" $p90_mean_ct_stats_tx_count_txt "\\n" $p99_mean_ct_stats_tx_count_txt "\\n"
 printf -v s_ct_stats_number_of_accts "%s%s%s%s%s%s%s%s" $mean_ct_stats_num_of_accts_txt "\\n" $max_ct_stats_num_of_accts_txt "\\n" $p90_ct_stats_num_of_accts_txt "\\n" $p99_ct_stats_num_of_accts_txt "\\n"
 printf -v blocks_fill "%s%s%s%s%s%s%s%s%s%s" $total_blocks_txt "\\n" $blocks_fill_50_txt "\\n" $blocks_fill_90_txt "\\n" $blocks_fill_50_percent_txt "\\n"  $blocks_fill_90_percent_txt "\\n"
+printf -v skip_rate "%s%s%s%s%s%s" $mean_skip_rate_txt "\\n" $max_skip_rate_txt "\\n" $skip_rate_90_txt "\\n"
+
 # combine all data
-printf -v s_detail_ret "%s%s%s%s%s%s%s%s%s%s" $s_time_start $s_time_end $s_slot $s_tx_count $s_tower_vote_distance $s_optimistic_slot_elapsed $s_ct_stats_block_cost $s_ct_stats_tx_count $s_ct_stats_number_of_accts $blocks_fill
+printf -v s_detail_ret "%s%s%s%s%s%s%s%s%s%s%s" $s_time_start $s_time_end $s_slot $s_tx_count $s_tower_vote_distance $s_optimistic_slot_elapsed $s_ct_stats_block_cost $s_ct_stats_tx_count $s_ct_stats_number_of_accts $blocks_fill $skip_rate
 ## Compose block content
 conf='"```'${test_config}'```"'
 detail='"```'${s_detail_ret}'```"'


### PR DESCRIPTION
[problem]
There are requests about adding skip-rate of slots to the dos report
[solution]
add mean_skip_rate/max_skip_rate/skip_rate_90 to the report by using pipeline query of FLUX language.
[method]
1. finding max and min of slots and blocks for each host_id
2. find skip_slot by calculating block_diff & slot diff for each host_id
3. get skip_rate_percent by "r.skip_slot*100/r.slot_diff " 
4. get the mean/max/90% of skip_rate by calculating among hosts.
5. write mean_skip_rate/max_skip_rate/skip_rate_90 to the report and influxdb

 