### PR TITLE
add mean_skip_rate before bench-tps start. fullfill #39

### DIFF
--- a/discord.sh
+++ b/discord.sh
@@ -33,8 +33,8 @@ printf -v s_ct_stats_number_of_accts '%s\\n%s\\n%s\\n%s' \
         "$mean_ct_stats_num_of_accts_txt" "$max_ct_stats_num_of_accts_txt" "$p90_ct_stats_num_of_accts_txt" "$p99_ct_stats_num_of_accts_txt"
 printf -v blocks_fill '%s\\n%s\\n%s\\n%s\\n%s' \
         "$total_blocks_txt" "$blocks_fill_50_txt" "$blocks_fill_90_txt" "$blocks_fill_50_percent_txt" "$blocks_fill_90_percent_txt"
-printf -v skip_rate '%s\\n%s\\n%s\\n' \
-        "$mean_skip_rate_txt" "$max_skip_rate_txt" "$skip_rate_90_txt"
+printf -v skip_rate '%s\\n%s\\n%s\\n%s\\n' \
+        "$mean_skip_rate_txt" "$max_skip_rate_txt" "$skip_rate_90_txt" "$mean_skip_rate_b4_test_txt"
 
 printf -v buildkite_link  '%s' "[Buildkite]($BUILDKITE_BUILD_URL)"
 printf -v grafana_link  '%s' "[Grafana]($gf_url)"

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -337,6 +337,12 @@ get_value
 skip_rate_90_txt="skip_rate_90_txt: $precision%"
 DATAPOINT[skip_rate_90]="$_value"
 
+result_input="${FLUX_RESULT['mean_skip_rate_b4_test']}"
+get_value
+[[ $_value != "na" ]] && printf -v precision "%.2f" "$_value" || precision="na"
+mean_skip_rate_b4_test_txt="mean_skip_rate_b4_test: $precision%"
+DATAPOINT[mean_skip_rate_b4_test]="$_value"
+
 #write data report to the influx
 
 build="$BUILDKITE_BUILD_NUMBER"

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -53,6 +53,7 @@ stop_time=$STOP_TIME
 stop_time2=$STOP_TIME2
 
 ## make sure 
+source utils.sh
 source influx_data.sh
 
 query(){

--- a/dos-report.sh
+++ b/dos-report.sh
@@ -335,7 +335,7 @@ DATAPOINT[max_skip_rate]="$_value"
 result_input="${FLUX_RESULT['skip_rate_90']}"
 get_value
 [[ $_value != "na" ]] && printf -v precision "%.2f" "$_value" || precision="na"
-skip_rate_90_txt="skip_rate_90_txt: $precision%"
+skip_rate_90_txt="skip_rate_90: $precision%"
 DATAPOINT[skip_rate_90]="$_value"
 
 result_input="${FLUX_RESULT['mean_skip_rate_b4_test']}"


### PR DESCRIPTION
[issue]
A request for a referenced mean_skip_rate right before the test so that we can compare the "stable" time with testing period.
[solution]
query the mean_skip_rate for 1 hr before bench-tps start