### PR TITLE
full fill issue #41

### DIFF
--- a/influx_data.sh
+++ b/influx_data.sh
@@ -13,34 +13,27 @@ _end_slot='from(bucket: "tds")|> range(start:'${stop_time2}' ,stop:'${stop_time}
 
 # TPS
 _mean_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count")
-	   				|> aggregateWindow(every: '${window_interval}', fn: mean)
-					|> group()|>mean()|>toInt()
-					|> drop(columns: ["_start", "_stop","count"])'
-_max_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count")
-	   				|> aggregateWindow(every: '${window_interval}', fn: max)
-					|> group()|>max()|>toInt()
-					|> drop(columns: ["_measurement", "_field", "_start", "_stop","_time","host_id","count"])'
-_min_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count")
-	   				|> aggregateWindow(every: '${window_interval}', fn: min)
-					|> group()|>min()|>toInt()
-					|> drop(columns: ["_measurement", "_field", "_start", "_stop","_time","host_id","count"])'
+    				|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
+    				|> aggregateWindow(every:'${window_interval}', fn: mean)
+    				|> median()|> group() |> mean()'
 
+_max_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
+    				|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
+    				|> aggregateWindow(every:'${window_interval}', fn: max)
+    				|> median()|> group() |> max()'
+_min_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
+    				|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
+    				|> aggregateWindow(every:'${window_interval}', fn: min)
+    				|> median()|> group() |> min()'
 _90_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count" )
+					|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
     				|> aggregateWindow(every: '${window_interval_long}',  fn: (column, tables=<-) => tables |> quantile(q: 0.9))
-    				|> group()
-    				|> quantile(column: "_value", q:0.9)|>toInt()
-    				|> drop(columns: ["_measurement", "_field", "_start", "_stop","count"])'
+    				|> group()|> quantile(column: "_value", q:0.9)|>toInt()'
 
 _99_tx_count='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')
-					|> filter(fn: (r) => r._measurement == "bank-process_transactions" and r._field == "count" )
+					|> filter(fn: (r) => r._measurement == "replay-slot-stats" and r._field == "total_transactions")
     				|> aggregateWindow(every: '${window_interval_long}',  fn: (column, tables=<-) => tables |> quantile(q: 0.99))
-    				|> group()
-    				|> quantile(column: "_value", q:0.99)|>toInt()
-    				|> drop(columns: ["_measurement", "_field", "_start", "_stop","count"])'
+    				|> group()|> quantile(column: "_value", q:0.99)|>toInt()'
 
 # tower_vote_distance
 _mean_tower_vote_distance='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${stop_time}')

--- a/influx_data.sh
+++ b/influx_data.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # slot
+source utils.sh
 _start_slot='from(bucket: "tds")|> range(start:'${start_time}' ,stop:'${start_time2}')
 			|> filter(fn: (r) => r._measurement == "optimistic_slot")
  			|> group(columns: ["slot"])|> median()


### PR DESCRIPTION
[problem]
The "bank-process_transactions" datapoint, which was used by dos-report to calculate mean_tps, has been removed in v1.16.
https://github.com/solana-labs/solana/pull/31398
[solution]
modify influx query similar to below
https://github.com/solana-labs/solana/pull/31531